### PR TITLE
Per Request Managed Diagnostic Context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ plugins {
 apply plugin: "org.junit.platform.gradle.plugin"
 apply plugin: "org.springframework.boot"
 
-jar {
+bootJar {
   baseName = "jv-server"
   version = "0.1.0-SNAPSHOT"
 }
@@ -92,15 +92,6 @@ junitPlatform {
 
 dependencies {
     compile "com.google.guava:guava:${versions.guava}"
-//    compile "org.springframework:spring-core:${versions.spring.core}"
-//    compile "org.springframework:spring-web:${versions.spring.core}"
-//    compile "org.springframework:spring-webmvc:${versions.spring.core}"
-//    compile ("org.springframework.boot:spring-boot-starter:${versions.spring.boot}") {
-//        exclude module: "org.springframework:spring-core"
-//    }
-//    compile "org.springframework.boot:spring-boot-actuator:${versions.spring.boot}"
-//    compile "org.springframework.boot:spring-boot-starter-undertow:${versions.spring.boot}"
-
     compile ("org.springframework.boot:spring-boot-starter-web:${versions.spring.boot}") {
         exclude group: "org.springframework.boot", module: "spring-boot-starter-json"
         exclude group: "org.springframework.boot", module: "spring-boot-starter-tomcat"
@@ -127,10 +118,10 @@ dependencies {
 }
 
 docker {
-//    dependsOn test, jar, bootJar
-    name "${group}/${jar.baseName}"
+    dependsOn assemble
+    name "${group}/${bootJar.baseName}"
     dockerfile file("Dockerfile")
-    files jar.archivePath
-    buildArgs([JAR_FILE: "${jar.archiveName}"])
+    files bootJar.archivePath
+    buildArgs([JAR_FILE: "${bootJar.archiveName}"])
 }
 

--- a/src/main/java/net/cockamamy/jv/Endpoint.java
+++ b/src/main/java/net/cockamamy/jv/Endpoint.java
@@ -16,15 +16,20 @@
 
 package net.cockamamy.jv;
 
+import static com.google.common.base.Preconditions.*;
+import static net.cockamamy.jv.util.MorePreconditions.checkArgumentNotBlank;
+import static net.cockamamy.jv.util.MorePreconditions.checkArgumentNotNull;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import java.io.Serializable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
+import net.cockamamy.jv.util.MorePreconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -56,6 +61,8 @@ public class Endpoint {
     @GetMapping("/{key}")
     public ResponseEntity<String> getValue(@PathVariable final String key) {
 
+        checkArgumentNotBlank(key);
+
         LOG.debug("Getting object with key {}", key);
         final Value value = kvStore.get(key);
         return value == null ? ResponseEntity.notFound().build()
@@ -69,6 +76,10 @@ public class Endpoint {
         @RequestHeader("Content-Type") final MediaType contentType,
         @RequestBody final String value) {
 
+        checkArgumentNotBlank(key);
+        checkArgumentNotNull(contentType);
+        checkArgumentNotBlank(value);
+
         LOG.debug("Putting key {} with content type {} and a value of {}", key, contentType, value);
         kvStore.put(key, new Value(contentType, value));
 
@@ -76,6 +87,8 @@ public class Endpoint {
 
     @DeleteMapping("/{key}")
     public ResponseEntity<String> deleteValue(@PathVariable final String key) {
+
+        checkArgumentNotBlank(key);
 
         LOG.debug("Deleting key {}", key);
         final Value deletedValue = kvStore.remove(key);
@@ -92,8 +105,13 @@ public class Endpoint {
         private final String object;
 
         private Value(@Nonnull final MediaType contentType, @Nonnull final String object) {
+
+            checkArgumentNotNull(contentType);
+            checkArgumentNotBlank(object);
+
             this.contentType = contentType;
             this.object = object;
+
         }
 
         @Nonnull

--- a/src/main/java/net/cockamamy/jv/ManagedDiagnosticContextFilter.java
+++ b/src/main/java/net/cockamamy/jv/ManagedDiagnosticContextFilter.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 John S. Burwell III
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.cockamamy.jv;
+
+import static net.cockamamy.jv.util.MorePreconditions.checkArgumentNotNull;
+
+import java.io.IOException;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Component
+@Immutable
+public final class ManagedDiagnosticContextFilter implements Filter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManagedDiagnosticContextFilter.class);
+
+    public final static String REQUEST_ID_HEADER = "JV-Request-Id";
+
+    private static String newRequestId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void init(final FilterConfig filterConfig) throws ServletException {
+        // DO nothing
+    }
+
+    @Override
+    public void doFilter(@Nonnull final ServletRequest request, @Nonnull final ServletResponse response,
+        @Nonnull final FilterChain chain)
+        throws IOException, ServletException {
+
+        checkArgumentNotNull(request);
+        checkArgumentNotNull(response);
+        checkArgumentNotNull(chain);
+
+        try {
+            final String requestId = newRequestId();
+            final HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+            LOG.trace("Associating required id {} with request {}", requestId, request);
+            httpResponse.addHeader(REQUEST_ID_HEADER, requestId);
+            MDC.put("requestId", newRequestId());
+
+            chain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+
+    }
+
+    @Override
+    public void destroy() {
+        // Do nothing
+    }
+
+}

--- a/src/main/java/net/cockamamy/jv/util/MorePreconditions.java
+++ b/src/main/java/net/cockamamy/jv/util/MorePreconditions.java
@@ -1,0 +1,17 @@
+package net.cockamamy.jv.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class MorePreconditions {
+
+    private MorePreconditions() { }
+
+    public static void checkArgumentNotNull(final Object argument) {
+        checkArgument(argument != null);
+    }
+
+    public static void checkArgumentNotBlank(final String argument) {
+        checkArgument(argument != null && argument.isEmpty() == false);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+logging.pattern.level=%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %mdc{requestId} %logger{36} - %msg%n
+logging.level.net.cockamamy.jv=DEBUG

--- a/src/test/java/net/cockamamy/jv/EndpointTest.java
+++ b/src/test/java/net/cockamamy/jv/EndpointTest.java
@@ -21,13 +21,16 @@ import static java.nio.charset.Charset.defaultCharset;
 import static java.nio.file.Files.readAllBytes;
 import static net.cockamamy.jv.Endpoint.BASE_URI;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static net.cockamamy.jv.ManagedDiagnosticContextFilter.REQUEST_ID_HEADER;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
@@ -70,7 +73,8 @@ public class EndpointTest {
         client.perform(put(uri)
             .contentType(mediaType)
             .content(content))
-            .andExpect(status().isCreated());
+            .andExpect(status().isCreated())
+            .andExpect(header().string(REQUEST_ID_HEADER, anything()));
 
         return uri;
 
@@ -102,6 +106,7 @@ public class EndpointTest {
 
         client.perform(get(objectURI))
             .andExpect(status().isOk())
+            .andExpect(header().string(REQUEST_ID_HEADER, anything()))
             .andExpect(content().contentType(mediaType))
             .andExpect(content().string(jsonObject));
 
@@ -111,6 +116,7 @@ public class EndpointTest {
     public void testUnsuccessfulGetObject(@Autowired @Nonnull final MockMvc client)
         throws Exception {
         client.perform(get(join("/", BASE_URI, randomKey())))
+            .andExpect(header().string(REQUEST_ID_HEADER, anything()))
             .andExpect(status().isNotFound());
     }
 
@@ -124,6 +130,7 @@ public class EndpointTest {
 
         client.perform(delete(objectURI))
             .andExpect(status().isOk())
+            .andExpect(header().string(REQUEST_ID_HEADER, anything()))
             .andExpect(content().contentType(mediaType))
             .andExpect(content().string(jsonObject));
 
@@ -133,6 +140,7 @@ public class EndpointTest {
     public void testUnsuccessfulDeleteObject(@Autowired @Nonnull final MockMvc client)
         throws Exception {
         client.perform(delete(join("/", BASE_URI, randomKey())))
+            .andExpect(header().string(REQUEST_ID_HEADER, anything()))
             .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
  * Adds ManagedDiagnosticContextFilter to assigned an ID to each
request, configure the LogBack MDC, and add a header with the ID
  * Updates EndpoointTest to verify the presence of the request ID
header for each call
  * Adds the MorePreconditions utility class to simplify repetitive
precondition checks and precondition checks to Endpoint
  * Adds a default application.properties to output the request id to all
log messages